### PR TITLE
Make SHM's current face lighter

### DIFF
--- a/subatomic-theme.el
+++ b/subatomic-theme.el
@@ -794,7 +794,7 @@ The theme has to be reloaded after changing anything in this group."
    ;; structured-haskell-mode
 
    `(shm-current-face
-     ((t (:background ,midnight-3))))
+     ((t (:background ,midnight-2))))
 
    `(shm-quarantine-face
      ((t (:background ,midnight-red))))


### PR DESCRIPTION
With `midnight-3` colour commentary delimiters becomes totally invisible
when they are located inside current node highlighted by structured
haskell mode (because they have same foreground colour). Switching to
`midnight-2` colour resolve this issue, and the colour itself is still
good enough to be used as structured-haskell-mode current face.